### PR TITLE
[Hotfix] Remover typename de queries

### DIFF
--- a/src/helpers/__test__/testHelper.ts
+++ b/src/helpers/__test__/testHelper.ts
@@ -20,10 +20,8 @@ export function buildGeneralModuleAsserts(
 }
 
 export function buildBaseAsserts(result: unknown, referenceObject: unknown, mock?: unknown) {
-  Object.keys(result)
-    .filter(key => key !== '__typename')
-    .forEach(key => {
-      mock && expect(result[key]).toEqual(mock[key])
-      expect(typeof result[key] === typeof referenceObject[key] || result[key] === null).toBeTruthy()
-    })
+  Object.keys(result).forEach(key => {
+    mock && expect(result[key]).toEqual(mock[key])
+    expect(typeof result[key] === typeof referenceObject[key] || result[key] === null).toBeTruthy()
+  })
 }

--- a/src/modules/app/__test__/apps.test.ts
+++ b/src/modules/app/__test__/apps.test.ts
@@ -13,7 +13,7 @@ describe('Apps Module', () => {
   it('Should get apps by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: AppFields[] = ['id', 'slug', 'content']
     const appsResult = await AppService.getById(ID_FILTER, [...SELECTED_FIELDS])
-    const appsResultFields = Object.keys(appsResult).filter(key => key != '__typename')
+    const appsResultFields = Object.keys(appsResult)
     expect(appsResultFields).toEqual(SELECTED_FIELDS)
     expect(appsResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/blog/category/__test__/blog.category.test.ts
+++ b/src/modules/blog/category/__test__/blog.category.test.ts
@@ -13,7 +13,7 @@ describe('Blog Category Module', () => {
   it('Should get blog category by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: BlogCategoryFields[] = ['id', 'name']
     const blogCategoryResult = await BlogCategoryService.getById(ID_FILTER, SELECTED_FIELDS)
-    const blogCategoryResultFields = Object.keys(blogCategoryResult).filter(key => key != '__typename')
+    const blogCategoryResultFields = Object.keys(blogCategoryResult)
     expect(blogCategoryResultFields).toEqual(SELECTED_FIELDS)
     expect(blogCategoryResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/blog/post/__test__/blog.post.test.ts
+++ b/src/modules/blog/post/__test__/blog.post.test.ts
@@ -13,7 +13,7 @@ describe('Blog Post Module', () => {
   it('Should get blog post by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: BlogPostFields[] = ['id', 'name']
     const blogPostResult = await BlogPostService.getById(ID_FILTER, SELECTED_FIELDS)
-    const blogPostResultKeys = Object.keys(blogPostResult).filter(key => key != '__typename')
+    const blogPostResultKeys = Object.keys(blogPostResult)
     expect(blogPostResultKeys).toEqual(SELECTED_FIELDS)
     expect(blogPostResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/brand/__test__/brand.test.ts
+++ b/src/modules/brand/__test__/brand.test.ts
@@ -13,7 +13,7 @@ describe('Brand Module', () => {
   it('Should get brand by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: BrandFields[] = ['id', 'name', 'slug']
     const brandResult = await BrandService.getById(ID_FILTER, [...SELECTED_FIELDS])
-    const brandResultFields = Object.keys(brandResult).filter(key => key != '__typename')
+    const brandResultFields = Object.keys(brandResult)
 
     expect(brandResultFields).toEqual(SELECTED_FIELDS)
   })

--- a/src/modules/cart/__test__/add.cart.test.ts
+++ b/src/modules/cart/__test__/add.cart.test.ts
@@ -20,19 +20,19 @@ describe('Cart Module', () => {
     })
   })
 
-  // it('Should add item and return cart with selected fields successfully', async () => {
-  //   const cartResult = await CartService.addItem({ items: SINGLE_ITEM_TO_BE_ADDED_SAMPLE }, [...SELECTED_FIELDS])
-  //   const cartResultFields = Object.keys(cartResult).filter(key => key != '__typename')
-  //   expect(cartResultFields).toEqual(SELECTED_FIELDS)
-  //   expect(cartResultFields.length).toEqual(SELECTED_FIELDS.length)
-  // })
+  it('Should add item and return cart with selected fields successfully', async () => {
+    const cartResult = await CartService.addItem({ items: SINGLE_ITEM_TO_BE_ADDED_SAMPLE }, [...SELECTED_FIELDS])
+    const cartResultFields = Object.keys(cartResult)
+    expect(cartResultFields).toEqual(SELECTED_FIELDS)
+    expect(cartResultFields.length).toEqual(SELECTED_FIELDS.length)
+  })
 
-  // it('Should add multiple items and return cart with all fields successfully', async () => {
-  //   const cartResult = await CartService.addItem({ items: MULTIPLE_ITEMS_TO_BE_ADDED_SAMPLE })
-  //   expect(cartResult.items.length).toEqual(MULTIPLE_ITEMS_TO_BE_ADDED_SAMPLE.length)
-  // })
+  it('Should add multiple items and return cart with all fields successfully', async () => {
+    const cartResult = await CartService.addItem({ items: MULTIPLE_ITEMS_TO_BE_ADDED_SAMPLE })
+    expect(cartResult.items.length).toEqual(MULTIPLE_ITEMS_TO_BE_ADDED_SAMPLE.length)
+  })
 
-  // it('Should try to add item with invalid variation_id and it should throw error', async () => {
-  //   expect(async () => await CartService.addItem({ items: [{ variation_id: 999, quantity: 1 }] })).rejects.toThrow
-  // })
+  it('Should try to add item with invalid variation_id and it should throw error', async () => {
+    expect(async () => await CartService.addItem({ items: [{ variation_id: 999, quantity: 1 }] })).rejects.toThrow
+  })
 })

--- a/src/modules/cart/__test__/delete.cart.test.ts
+++ b/src/modules/cart/__test__/delete.cart.test.ts
@@ -42,7 +42,7 @@ describe('Cart Module', () => {
       [...SELECTED_FIELDS]
     )
 
-    const cartResultFields = Object.keys(deleteItemCartWithSelectedFields).filter(key => key != '__typename')
+    const cartResultFields = Object.keys(deleteItemCartWithSelectedFields)
     expect(cartResultFields).toEqual(SELECTED_FIELDS)
     expect(cartResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/cart/__test__/get.cart.test.ts
+++ b/src/modules/cart/__test__/get.cart.test.ts
@@ -29,7 +29,7 @@ describe('Cart Module', () => {
   it('Should get cart with selected fields successfully', async () => {
     const cartResult = await CartService.getCart(firstAddedItemsCart.token, [...SELECTED_FIELDS])
 
-    const cartResultFields = Object.keys(cartResult).filter(key => key != '__typename')
+    const cartResultFields = Object.keys(cartResult)
     expect(cartResultFields).toEqual(SELECTED_FIELDS)
     expect(cartResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/cart/__test__/update.cart.test.ts
+++ b/src/modules/cart/__test__/update.cart.test.ts
@@ -45,7 +45,7 @@ describe('Cart Module', () => {
       [...SELECTED_FIELDS]
     )
 
-    const cartResultFields = Object.keys(updatedItemCartWithSelectedFields).filter(key => key != '__typename')
+    const cartResultFields = Object.keys(updatedItemCartWithSelectedFields)
     expect(cartResultFields).toEqual(SELECTED_FIELDS)
     expect(cartResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/category/__test__/category.test.ts
+++ b/src/modules/category/__test__/category.test.ts
@@ -12,7 +12,7 @@ describe('Category Module', () => {
   it('Should get category by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: CategoryFields[] = ['id', 'name', 'position', 'depth', 'breadcrumb']
     const categoryResult = await CategoryService.getById(ID_FILTER, [...SELECTED_FIELDS])
-    const categoryResultKeys = Object.keys(categoryResult).filter(key => key != '__typename')
+    const categoryResultKeys = Object.keys(categoryResult)
     expect(categoryResultKeys).toEqual(SELECTED_FIELDS)
     expect(categoryResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/freight/__test__/freight.test.ts
+++ b/src/modules/freight/__test__/freight.test.ts
@@ -16,7 +16,7 @@ describe('Freight Module', () => {
   it('Should get freight with selected fields successfully', async () => {
     const SELECTED_FIELDS: FreightFields[] = ['id', 'name']
     const freightResult = await FreightService.getList(SHIPPING_FILTER, [...SELECTED_FIELDS])
-    const freightResultKeys = Object.keys(freightResult[0]).filter(key => key != '__typename')
+    const freightResultKeys = Object.keys(freightResult[0])
     expect(freightResultKeys).toEqual(SELECTED_FIELDS)
     expect(freightResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/landing-pages/__test__/landing.pages.test.ts
+++ b/src/modules/landing-pages/__test__/landing.pages.test.ts
@@ -12,7 +12,7 @@ describe('Landing Pages Module', () => {
   it('Should get landing page by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: LandingPageFields[] = ['id', 'name', 'slug', 'content']
     const landingPageResult: LandingPage<any> = await LandingPagesService.getById(ID_FILTER, SELECTED_FIELDS)
-    const landingPageResultFields = Object.keys(landingPageResult).filter(key => key != '__typename')
+    const landingPageResultFields = Object.keys(landingPageResult)
     expect(landingPageResultFields).toEqual(SELECTED_FIELDS)
     expect(landingPageResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/menu/__test__/menu.test.ts
+++ b/src/modules/menu/__test__/menu.test.ts
@@ -13,7 +13,7 @@ describe('Menu Module', () => {
 
   it('Should get menu by id with selected fields successfully', async () => {
     const menuResult: Menu = await MenuService.getById(ID_FILTER, [...SELECTED_FIELDS])
-    const menuResultKeys = Object.keys(menuResult).filter(key => key != '__typename')
+    const menuResultKeys = Object.keys(menuResult)
     expect(menuResultKeys).toEqual(SELECTED_FIELDS)
     expect(menuResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/pages/__test__/pages.test.ts
+++ b/src/modules/pages/__test__/pages.test.ts
@@ -12,7 +12,7 @@ describe('Pages Module', () => {
   it('Should get page by id with selected fields successfully', async () => {
     const SELECTED_FIELDS: Array<PageFields> = ['id', 'slug']
     const pagesResult = await PagesService.getById(ID_FILTER, [...SELECTED_FIELDS])
-    const pagesResultKeys = Object.keys(pagesResult).filter(key => key != '__typename')
+    const pagesResultKeys = Object.keys(pagesResult)
     expect(pagesResultKeys).toEqual(SELECTED_FIELDS)
     expect(pagesResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/product/__test__/product.test.ts
+++ b/src/modules/product/__test__/product.test.ts
@@ -16,7 +16,7 @@ describe('Product Module', () => {
   it('Should get product by id with selected fields successfully', async () => {
     const FILTER_ID = '2914059'
     const productResult = await ProductService.getById(FILTER_ID, [...SELECTED_FIELDS])
-    const productResultFields = Object.keys(productResult).filter(key => key != '__typename')
+    const productResultFields = Object.keys(productResult)
     expect(productResultFields).toEqual(SELECTED_FIELDS)
     expect(productResultFields.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/scripts/__test__/scripts.test.ts
+++ b/src/modules/scripts/__test__/scripts.test.ts
@@ -25,7 +25,7 @@ describe('Script Module', () => {
   it('Should get all scripts with selected fields successfully', async () => {
     const scriptResult = await ScriptsService.getList([...SELECTED_FIELDS])
     scriptResult.forEach(script => {
-      const scriptKeys = Object.keys(script).filter(key => key != '__typename')
+      const scriptKeys = Object.keys(script)
       expect(scriptKeys).toEqual(SELECTED_FIELDS)
       expect(scriptKeys.length).toEqual(SELECTED_FIELDS.length)
     })

--- a/src/modules/shop/__test__/shop.test.ts
+++ b/src/modules/shop/__test__/shop.test.ts
@@ -12,7 +12,7 @@ describe('Shop Module', () => {
 
   it('Should Get shop with selected fields successfully', async () => {
     const shopResult: Shop = await ShopService.getShop([...SELECTED_FIELDS])
-    const shopResultKeys = Object.keys(shopResult).filter(key => key != '__typename')
+    const shopResultKeys = Object.keys(shopResult)
     expect(shopResultKeys).toEqual(SELECTED_FIELDS)
     expect(shopResultKeys.length).toEqual(SELECTED_FIELDS.length)
   })

--- a/src/modules/user/__test__/user.test.ts
+++ b/src/modules/user/__test__/user.test.ts
@@ -15,7 +15,7 @@ describe('User Module', () => {
     const LOGIN_CREDENTIALS = { email: 'diovani.dooca@gmail.com', password: 'Teste123' }
     const SELECTED_FIELDS: Array<UserFields> = ['id', 'phone']
     const loginResult: User = await UserService.auth(LOGIN_CREDENTIALS, SELECTED_FIELDS)
-    expect(Object.keys(loginResult).filter(key => key != '__typename')).toEqual(SELECTED_FIELDS)
+    expect(Object.keys(loginResult)).toEqual(SELECTED_FIELDS)
   })
 
   it('Should try to do login with incorrect credentials and an error should be thrown', async () => {

--- a/src/services/GraphqlService.ts
+++ b/src/services/GraphqlService.ts
@@ -10,6 +10,7 @@ class GraphqlService {
       url: api_url,
       requestPolicy: 'cache-first',
       exchanges: defaultExchanges,
+      maskTypename: true,
       fetchOptions: {
         headers: {
           token: token,


### PR DESCRIPTION
## [Hotfix] Remover typename de queries

### Changes

- Ajustada config do client gql para mascarar o typename do resultado das queries