### PR TITLE
[hotfix] Revisa dados de retorno de Blog

### DIFF
--- a/src/services/navigation/navigation-service.ts
+++ b/src/services/navigation/navigation-service.ts
@@ -12,7 +12,7 @@ export class NavigationService {
   }
 
   static getCategoryLink(categorySlug: string): string {
-    return `/${categorySlug}/c`
+    return `/blog/${categorySlug}`
   }
 
   static getInstitutionalLink(institutionalSlug: string): string {

--- a/src/services/navigation/navigation-service.ts
+++ b/src/services/navigation/navigation-service.ts
@@ -12,7 +12,7 @@ export class NavigationService {
   }
 
   static getCategoryLink(categorySlug: string): string {
-    return `/blog/${categorySlug}`
+    return `/${categorySlug}/c`
   }
 
   static getInstitutionalLink(institutionalSlug: string): string {

--- a/src/types/PostTypes.ts
+++ b/src/types/PostTypes.ts
@@ -12,14 +12,10 @@ export interface Post {
   updatedAt: string
   url: string
   image?: nullable<Image>
-  tags?: nullable<Tag[]>
+  tags?: nullable<string>
   active?: nullable<boolean>
   metaTitle?: nullable<string>
   metaDescription?: nullable<string>
   metaKeywords?: nullable<string>
   category?: nullable<Category>
-}
-
-interface Tag {
-  name: string
 }


### PR DESCRIPTION
## Revisar os dados de retorno de Blog 
[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront-7?workitem=5700)

Changes:
- Atualiza `type` do Blog
- Modifica retorno do `getCategoryLink` 
