### PR TITLE
[Task] Não retornar compre junto se estiver com o countdown ativo

### DIFF
--- a/src/modules/buy-together/BuyTogetherQueries.ts
+++ b/src/modules/buy-together/BuyTogetherQueries.ts
@@ -197,12 +197,20 @@ export class BuyTogetherQueries {
           slug
         }
       }
+      releaseDate {
+        releaseDate
+        now
+      }
       productId
       createdAt
       variations {
         id
         name
         slug
+        releaseDate {
+          releaseDate
+          now
+        }
         payments {
           id
           gatewayId

--- a/src/modules/buy-together/BuyTogetherTypes.ts
+++ b/src/modules/buy-together/BuyTogetherTypes.ts
@@ -25,6 +25,11 @@ export interface BuyTogether {
   product: Product
 }
 
+export interface ReleaseDate {
+  releaseDate: string
+  now: string
+}
+
 export interface PaymentInstallment {
   markup: number
   parcel: number
@@ -220,6 +225,7 @@ export interface Product {
   payments: Payment[]
   gtin: string
   mpn: string
+  releaseDate: ReleaseDate
   additionalShippingTime: number
   externalId?: string
   categoryDefaultId?: number


### PR DESCRIPTION
## [Task] Não retornar compre junto se estiver com o countdown ativo

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/sprint%2025?workitem=9683)

### Changes:

- Adicionado releaseDate na query do BuyTogether para checar se tem lançamento no front components
