### PR TITLE
[US] Consumidor final visualiza e/ou faz compra de produto com data de lançamento

### DIFF
--- a/src/modules/buy-together/BuyTogetherQueries.ts
+++ b/src/modules/buy-together/BuyTogetherQueries.ts
@@ -197,12 +197,20 @@ export class BuyTogetherQueries {
           slug
         }
       }
+      releaseDate {
+        releaseDate
+        now
+      }
       productId
       createdAt
       variations {
         id
         name
         slug
+        releaseDate {
+          releaseDate
+          now
+        }
         payments {
           id
           gatewayId

--- a/src/modules/buy-together/BuyTogetherTypes.ts
+++ b/src/modules/buy-together/BuyTogetherTypes.ts
@@ -25,6 +25,11 @@ export interface BuyTogether {
   product: Product
 }
 
+export interface ReleaseDate {
+  releaseDate: string
+  now: string
+}
+
 export interface PaymentInstallment {
   markup: number
   parcel: number
@@ -220,6 +225,7 @@ export interface Product {
   payments: Payment[]
   gtin: string
   mpn: string
+  releaseDate: ReleaseDate
   additionalShippingTime: number
   externalId?: string
   categoryDefaultId?: number

--- a/src/modules/buy-together/BuyTogetherTypes.ts
+++ b/src/modules/buy-together/BuyTogetherTypes.ts
@@ -1,3 +1,4 @@
+import { ReleaseDate } from '../../types/ReleaseDateTypes'
 import { ID } from '../../types/HelpersTypes'
 
 export type BuyTogetherFields =
@@ -23,11 +24,6 @@ export interface BuyTogether {
   active: boolean
   productsPivot: Product[]
   product: Product
-}
-
-export interface ReleaseDate {
-  releaseDate: string
-  now: string
 }
 
 export interface PaymentInstallment {

--- a/src/modules/product/ProductQueries.ts
+++ b/src/modules/product/ProductQueries.ts
@@ -9,6 +9,10 @@ export class ProductQueries {
     return this.fields.join()
   }
 
+  private getReleaseDateFields() {
+    return '{releaseDate, now}'
+  }
+
   private getImageFields() {
     return '{productId, src, alt, colorIds, variationIds, position}'
   }
@@ -127,6 +131,7 @@ export class ProductQueries {
       'description',
       'shortDescription',
       'relevance',
+      `releaseDate ${this.getReleaseDateFields()}`,
       'tags',
       'minQuantity',
       'maxQuantity',

--- a/src/modules/product/ProductTypes.ts
+++ b/src/modules/product/ProductTypes.ts
@@ -1,5 +1,6 @@
 import { PageableEdgeObject, PageableListObject, PaginationFilter } from '../../types/PaginationTypes'
 import { nullable } from '../../types/HelpersTypes'
+import { ReleaseDate } from '../../types/ReleaseDateTypes'
 import { SidebarFilter } from '../sidebar/SidebarTypes'
 
 export interface Product {
@@ -16,6 +17,7 @@ export interface Product {
   description?: string
   shortDescription?: string
   relevance?: number
+  releaseDate?: nullable<ReleaseDate>
   tags?: string
   minQuantity?: number
   maxQuantity?: number

--- a/src/types/ReleaseDateTypes.ts
+++ b/src/types/ReleaseDateTypes.ts
@@ -1,0 +1,4 @@
+export interface ReleaseDate {
+  releaseDate: string
+  now: string
+}

--- a/src/types/product/ProductTypes.ts
+++ b/src/types/product/ProductTypes.ts
@@ -9,6 +9,8 @@ import { ProductImage } from './ProductImageTypes'
 import { ComponentGroup } from './ComponentGroupTypes'
 import { ProductVariation } from './ProductVariationTypes'
 import { nullable } from '../HelpersTypes'
+import { ReleaseDate } from '../ReleaseDateTypes'
+
 export interface Product {
   id: number
   name: string
@@ -26,6 +28,7 @@ export interface Product {
   description?: nullable<string>
   shortDescription?: nullable<string>
   relevance?: nullable<number>
+  releaseDate?: nullable<ReleaseDate>
   tags?: nullable<string>
   minQuantity?: nullable<number>
   maxQuantity?: nullable<number>

--- a/src/types/product/ProductVariationTypes.ts
+++ b/src/types/product/ProductVariationTypes.ts
@@ -2,6 +2,7 @@ import { Color } from './ColorTypes'
 import { AttributeValue } from './AttributeTypes'
 import { ProductImage } from './ProductImageTypes'
 import { nullable } from '../HelpersTypes'
+import { ReleaseDate } from '../ReleaseDateTypes'
 
 export interface ProductVariation {
   id: number
@@ -11,6 +12,7 @@ export interface ProductVariation {
   updatedAt: string
   gridId?: nullable<number>
   colorId?: nullable<number>
+  releaseDate?: nullable<ReleaseDate>
   colorSecondaryId?: nullable<number>
   attributeValueId?: nullable<number>
   attributeValueSecondaryId?: nullable<number>


### PR DESCRIPTION
## [US] Consumidor final visualiza e/ou faz compra de produto com data de lançamento

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/sprint%2025?workitem=9172)

### Changes:

- Alterações para retornar o releaseDate no get de produto para satisfazer o launch-countdown do FrontComponents
