### PR TITLE
[Task] Otimizar query do buy-together

### DIFF
--- a/src/modules/buy-together/BuyTogetherQueries.ts
+++ b/src/modules/buy-together/BuyTogetherQueries.ts
@@ -1,11 +1,13 @@
+type QueryMode = 'restrict' | 'full'
+
 export class BuyTogetherQueries {
   fields: null | string[]
 
   constructor(fields) {
-    this.fields = fields || this.getAllFields()
+    this.fields = fields
   }
 
-  private getAllFields() {
+  private getAllFields(productQueryMode?: QueryMode) {
     return (
       this.fields ??
       `{
@@ -18,10 +20,107 @@ export class BuyTogetherQueries {
         dateFrom,
         dateTo,
         active,
-        product ${this.getProduct()},
-        productsPivot ${this.getProduct()}
+        product ${productQueryMode === 'restrict' ? this.getStrictProductFields() : this.getProduct()},
+        productsPivot ${productQueryMode === 'restrict' ? this.getStrictProductFields() : this.getProduct()}
       }`
     )
+  }
+
+  private getStrictProductFields() {
+    const imageFields = `
+    {
+      id
+      productId
+      src
+      alt
+      colorIds
+      variationIds
+    }`
+    const colorFields = `
+    {
+      id
+      name
+      slug
+      hexadecimal
+    }`
+    const attributeFields = `
+    {
+      id
+      name
+      slug
+      attributeId
+      attributeName
+      isActive
+    }`
+    const featureFields = `
+    {
+      id
+      name
+      slug
+      values {
+        id
+        name
+        slug
+      }
+    }`
+    const variationsFields = `
+    {
+      id
+      name
+      slug
+      releaseDate {
+        releaseDate
+        now
+      }
+      description
+      shortDescription
+      isVirtual
+      isPreSale
+      images ${imageFields}
+      priceOutOfStock
+      isSellOutOfStock
+      additionalTimeOutOfStock
+      balance
+      price
+      priceCompare
+      discount
+      billetDiscount
+      paymentsReason
+      color ${colorFields}
+      attribute ${attributeFields}
+      attributeSecondary ${attributeFields}
+      features ${featureFields}
+      productId
+      colors ${colorFields}
+    }
+    `
+    return `{
+      id
+      name
+      slug
+      description
+      shortDescription
+      images ${imageFields}
+      priceOutOfStock
+      isSellOutOfStock
+      balance
+      price
+      priceCompare
+      discount
+      billetDiscount
+      color ${colorFields}
+      attribute ${attributeFields}
+      attributeSecondary ${attributeFields}
+      features ${featureFields}
+      releaseDate {
+        releaseDate
+        now
+      }
+      productId
+      variations ${variationsFields}
+      sku
+      colors ${colorFields}
+    }`
   }
 
   private getProduct() {
@@ -484,10 +583,10 @@ export class BuyTogetherQueries {
     }`
   }
 
-  getOneFullQuery() {
+  getOneFullQuery(productQueryMode?: QueryMode) {
     return `query BuyTogether($filter: filterBuyTogether) {
       buyTogether(filter: $filter) 
-        ${this.getAllFields()}
+        ${this.getAllFields(productQueryMode)}
     }`
   }
 }

--- a/src/modules/buy-together/BuyTogetherRepositoryGql.ts
+++ b/src/modules/buy-together/BuyTogetherRepositoryGql.ts
@@ -5,7 +5,7 @@ import { BuyTogetherQueries } from './BuyTogetherQueries'
 export class BuyTogetherRepositoryGql {
   static async getByProductId(productId: number, fields?: BuyTogetherFields[]): Promise<BuyTogether> {
     const buyTogetherQuery = new BuyTogetherQueries(fields)
-    const buyTogetherGetOneQuery = buyTogetherQuery.getOneFullQuery()
+    const buyTogetherGetOneQuery = buyTogetherQuery.getOneFullQuery('restrict')
     const { buyTogether } = (await getClient().query(buyTogetherGetOneQuery, { filter: { productId } })) as {
       buyTogether: BuyTogether
     }

--- a/src/modules/buy-together/BuyTogetherTypes.ts
+++ b/src/modules/buy-together/BuyTogetherTypes.ts
@@ -11,6 +11,7 @@ export type BuyTogetherFields =
   | 'dateFrom'
   | 'dateTo'
   | 'active'
+  | 'product'
   | 'productsPivot'
 
 export interface BuyTogether {

--- a/src/modules/buy-together/__test__/buy-together.test.ts
+++ b/src/modules/buy-together/__test__/buy-together.test.ts
@@ -1,11 +1,31 @@
 import 'isomorphic-fetch'
 import { BuyTogetherService } from '../BuyTogetherService'
+import { BuyTogetherFields } from '../BuyTogetherTypes'
 
-const PRODUCT_ID_FILTER = 2915659
+const PRODUCT_ID_FILTER = 2915865
+const SELECTED_FIELDS: BuyTogetherFields[] = [
+  'id',
+  'name',
+  'title',
+  'buyButtonText',
+  'productId',
+  'colorId',
+  'dateFrom',
+  'dateTo',
+  'active',
+  'product',
+  'productsPivot'
+]
 
 describe('Buy Together Module', () => {
   it('Should get main product by id with all fields successfully', async () => {
     const productResult = await BuyTogetherService.getByProductId(PRODUCT_ID_FILTER)
+    expect(productResult.productId).toEqual(PRODUCT_ID_FILTER)
+  })
+  it('Should get main product by id with selected fields successfully', async () => {
+    const productResult = await BuyTogetherService.getByProductId(PRODUCT_ID_FILTER)
+    const productResultKeys = Object.keys(productResult)
+    expect(productResultKeys).toEqual(SELECTED_FIELDS)
     expect(productResult.productId).toEqual(PRODUCT_ID_FILTER)
   })
 })


### PR DESCRIPTION
## [Task] Otimizar query do buy-together

### Changes:

- Adição do parâmetro de tipo de query, `'full' | 'restrict'` para visar melhora de performance e dados carregados quando todos os dados não são necessários.
